### PR TITLE
Add tool yield stream events

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -85,3 +85,7 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+### Custom tool events
+
+Tools can stream their own progress updates using `ToolContext.yield_event`. Any object passed to this method will be emitted as a `ToolYieldStreamEvent` and will not modify the agent's output or context.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -55,6 +55,7 @@ from .stream_events import (
     RawResponsesStreamEvent,
     RunItemStreamEvent,
     StreamEvent,
+    ToolYieldStreamEvent,
 )
 from .tool import (
     CodeInterpreterTool,
@@ -219,6 +220,7 @@ __all__ = [
     "RunItemStreamEvent",
     "AgentUpdatedStreamEvent",
     "StreamEvent",
+    "ToolYieldStreamEvent",
     "FunctionTool",
     "FunctionToolResult",
     "ComputerTool",

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -866,6 +866,7 @@ class AgentRunner:
             context_wrapper=context_wrapper,
             run_config=run_config,
             tool_use_tracker=tool_use_tracker,
+            event_queue=streamed_result._event_queue,
         )
 
         RunImpl.stream_step_result_to_queue(single_step_result, streamed_result._event_queue)
@@ -933,6 +934,7 @@ class AgentRunner:
             context_wrapper=context_wrapper,
             run_config=run_config,
             tool_use_tracker=tool_use_tracker,
+            event_queue=None,
         )
 
     @classmethod
@@ -950,6 +952,7 @@ class AgentRunner:
         context_wrapper: RunContextWrapper[TContext],
         run_config: RunConfig,
         tool_use_tracker: AgentToolUseTracker,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     ) -> SingleStepResult:
         processed_response = RunImpl.process_model_response(
             agent=agent,
@@ -971,6 +974,7 @@ class AgentRunner:
             hooks=hooks,
             context_wrapper=context_wrapper,
             run_config=run_config,
+            event_queue=event_queue,
         )
 
     @classmethod

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, Union
 
+import asyncio
+import contextvars
+
 from typing_extensions import TypeAlias
 
 from .agent import Agent
@@ -57,5 +60,29 @@ class AgentUpdatedStreamEvent:
     type: Literal["agent_updated_stream_event"] = "agent_updated_stream_event"
 
 
-StreamEvent: TypeAlias = Union[RawResponsesStreamEvent, RunItemStreamEvent, AgentUpdatedStreamEvent]
+@dataclass
+class ToolYieldStreamEvent:
+    """An event emitted when a tool yields a value."""
+
+    tool_name: str
+    """Name of the tool that yielded the value."""
+
+    data: Any
+    """The data yielded by the tool."""
+
+    type: Literal["tool_yield_event"] = "tool_yield_event"
+
+
+# Context variable that tools use to stream yielded objects
+current_tool_event_queue: contextvars.ContextVar[
+    asyncio.Queue["ToolYieldStreamEvent"] | None
+] = contextvars.ContextVar("current_tool_event_queue", default=None)
+
+
+StreamEvent: TypeAlias = Union[
+    RawResponsesStreamEvent,
+    RunItemStreamEvent,
+    AgentUpdatedStreamEvent,
+    ToolYieldStreamEvent,
+]
 """A streaming event from an agent."""

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, fields
 from typing import Any
 
+from .stream_events import ToolYieldStreamEvent, current_tool_event_queue
+
 from .run_context import RunContextWrapper, TContext
 
 
@@ -15,9 +17,18 @@ class ToolContext(RunContextWrapper[TContext]):
     tool_call_id: str = field(default_factory=_assert_must_pass_tool_call_id)
     """The ID of the tool call."""
 
+    tool_name: str = field(default="")
+    """The name of the tool being executed."""
+
+    def yield_event(self, data: Any) -> None:
+        """Yield an object from the tool without affecting agent output."""
+        queue = current_tool_event_queue.get()
+        if queue is not None:
+            queue.put_nowait(ToolYieldStreamEvent(tool_name=self.tool_name, data=data))
+
     @classmethod
     def from_agent_context(
-        cls, context: RunContextWrapper[TContext], tool_call_id: str
+        cls, context: RunContextWrapper[TContext], tool_call_id: str, tool_name: str
     ) -> "ToolContext":
         """
         Create a ToolContext from a RunContextWrapper.
@@ -26,4 +37,4 @@ class ToolContext(RunContextWrapper[TContext]):
         base_values: dict[str, Any] = {
             f.name: getattr(context, f.name) for f in fields(RunContextWrapper) if f.init
         }
-        return cls(tool_call_id=tool_call_id, **base_values)
+        return cls(tool_call_id=tool_call_id, tool_name=tool_name, **base_values)

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -19,7 +19,7 @@ async def test_argless_function():
     tool = function_tool(argless_function)
     assert tool.name == "argless_function"
 
-    result = await tool.on_invoke_tool(ToolContext(context=None, tool_call_id="1"), "")
+    result = await tool.on_invoke_tool(ToolContext(context=None, tool_call_id="1", tool_name="argless_function"), "")
     assert result == "ok"
 
 
@@ -32,11 +32,11 @@ async def test_argless_with_context():
     tool = function_tool(argless_with_context)
     assert tool.name == "argless_with_context"
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), "")
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="argless_with_context"), "")
     assert result == "ok"
 
     # Extra JSON should not raise an error
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"a": 1}')
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="argless_with_context"), '{"a": 1}')
     assert result == "ok"
 
 
@@ -49,15 +49,15 @@ async def test_simple_function():
     tool = function_tool(simple_function, failure_error_function=None)
     assert tool.name == "simple_function"
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"a": 1}')
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="simple_function"), '{"a": 1}')
     assert result == 6
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"a": 1, "b": 2}')
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="simple_function"), '{"a": 1, "b": 2}')
     assert result == 3
 
     # Missing required argument should raise an error
     with pytest.raises(ModelBehaviorError):
-        await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), "")
+        await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="simple_function"), "")
 
 
 class Foo(BaseModel):
@@ -85,7 +85,7 @@ async def test_complex_args_function():
             "bar": Bar(x="hello", y=10),
         }
     )
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), valid_json)
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="complex_args_function"), valid_json)
     assert result == "6 hello10 hello"
 
     valid_json = json.dumps(
@@ -94,7 +94,7 @@ async def test_complex_args_function():
             "bar": Bar(x="hello", y=10),
         }
     )
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), valid_json)
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="complex_args_function"), valid_json)
     assert result == "3 hello10 hello"
 
     valid_json = json.dumps(
@@ -104,12 +104,12 @@ async def test_complex_args_function():
             "baz": "world",
         }
     )
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), valid_json)
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="complex_args_function"), valid_json)
     assert result == "3 hello10 world"
 
     # Missing required argument should raise an error
     with pytest.raises(ModelBehaviorError):
-        await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"foo": {"a": 1}}')
+        await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="complex_args_function"), '{"foo": {"a": 1}}')
 
 
 def test_function_config_overrides():
@@ -169,7 +169,7 @@ async def test_manual_function_tool_creation_works():
         assert tool.params_json_schema[key] == value
     assert tool.strict_json_schema
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"data": "hello"}')
+    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1", tool_name="test"), '{"data": "hello"}')
     assert result == "hello_done"
 
     tool_not_strict = FunctionTool(
@@ -184,7 +184,7 @@ async def test_manual_function_tool_creation_works():
     assert "additionalProperties" not in tool_not_strict.params_json_schema
 
     result = await tool_not_strict.on_invoke_tool(
-        ToolContext(None, tool_call_id="1"), '{"data": "hello", "bar": "baz"}'
+        ToolContext(None, tool_call_id="1", tool_name="test"), '{"data": "hello", "bar": "baz"}'
     )
     assert result == "hello_done"
 
@@ -195,7 +195,7 @@ async def test_function_tool_default_error_works():
         raise ValueError("test")
 
     tool = function_tool(my_func)
-    ctx = ToolContext(None, tool_call_id="1")
+    ctx = ToolContext(None, tool_call_id="1", tool_name="my_func")
 
     result = await tool.on_invoke_tool(ctx, "")
     assert "Invalid JSON" in str(result)
@@ -219,7 +219,7 @@ async def test_sync_custom_error_function_works():
         return f"error_{error.__class__.__name__}"
 
     tool = function_tool(my_func, failure_error_function=custom_sync_error_function)
-    ctx = ToolContext(None, tool_call_id="1")
+    ctx = ToolContext(None, tool_call_id="1", tool_name="my_func")
 
     result = await tool.on_invoke_tool(ctx, "")
     assert result == "error_ModelBehaviorError"
@@ -243,7 +243,7 @@ async def test_async_custom_error_function_works():
         return f"error_{error.__class__.__name__}"
 
     tool = function_tool(my_func, failure_error_function=custom_sync_error_function)
-    ctx = ToolContext(None, tool_call_id="1")
+    ctx = ToolContext(None, tool_call_id="1", tool_name="my_func")
 
     result = await tool.on_invoke_tool(ctx, "")
     assert result == "error_ModelBehaviorError"

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -16,7 +16,7 @@ class DummyContext:
 
 
 def ctx_wrapper() -> ToolContext[DummyContext]:
-    return ToolContext(context=DummyContext(), tool_call_id="1")
+    return ToolContext(context=DummyContext(), tool_call_id="1", tool_name="test")
 
 
 @function_tool


### PR DESCRIPTION
## Summary
- allow tools to yield custom objects
- stream tool yield events via `ToolYieldStreamEvent`
- document custom streaming events

## Testing
- `make format` *(fails: Failed to download `mkdocstrings-python`)*
- `make lint` *(fails: Failed to download `packaging`)*
- `make mypy` *(fails: Failed to download `openai`)*
- `make tests` *(fails: Failed to download `pycparser`)*

------
https://chatgpt.com/codex/tasks/task_e_685ea787fd548323b1d006dc7728eb37

## Summary by Sourcery

Introduce a mechanism for tools to emit custom streaming events and integrate yield event propagation through the agent execution pipeline.

New Features:
- Allow tools to yield arbitrary objects during execution as ToolYieldStreamEvent.
- Define and include ToolYieldStreamEvent in the StreamEvent union.

Enhancements:
- Propagate the event_queue parameter through agent run, run_impl, and tool invocation paths.
- Add a tool_name attribute to ToolContext and use a context variable to route yield events to the queue.

Documentation:
- Document custom tool yield events in the streaming guide.

Tests:
- Update tests to pass tool_name to ToolContext where required.