### PR TITLE
Add tool yield streaming events

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -54,6 +54,7 @@ from .stream_events import (
     AgentUpdatedStreamEvent,
     RawResponsesStreamEvent,
     RunItemStreamEvent,
+    ToolYieldStreamEvent,
     StreamEvent,
 )
 from .tool import (
@@ -218,6 +219,7 @@ __all__ = [
     "RawResponsesStreamEvent",
     "RunItemStreamEvent",
     "AgentUpdatedStreamEvent",
+    "ToolYieldStreamEvent",
     "StreamEvent",
     "FunctionTool",
     "FunctionToolResult",

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -5,7 +5,7 @@ import dataclasses
 import inspect
 from collections.abc import Awaitable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator, cast
 
 from openai.types.responses import (
     ResponseComputerToolCall,
@@ -64,7 +64,7 @@ from .logger import logger
 from .model_settings import ModelSettings
 from .models.interface import ModelTracing
 from .run_context import RunContextWrapper, TContext
-from .stream_events import RunItemStreamEvent, StreamEvent
+from .stream_events import RunItemStreamEvent, StreamEvent, ToolYieldStreamEvent
 from .tool import (
     ComputerTool,
     FunctionTool,
@@ -238,6 +238,7 @@ class RunImpl:
         hooks: RunHooks[TContext],
         context_wrapper: RunContextWrapper[TContext],
         run_config: RunConfig,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     ) -> SingleStepResult:
         # Make a copy of the generated items
         pre_step_items = list(pre_step_items)
@@ -253,6 +254,7 @@ class RunImpl:
                 hooks=hooks,
                 context_wrapper=context_wrapper,
                 config=run_config,
+                event_queue=event_queue,
             ),
             cls.execute_computer_actions(
                 agent=agent,
@@ -539,6 +541,7 @@ class RunImpl:
         hooks: RunHooks[TContext],
         context_wrapper: RunContextWrapper[TContext],
         config: RunConfig,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     ) -> list[FunctionToolResult]:
         async def run_single_tool(
             func_tool: FunctionTool, tool_call: ResponseFunctionToolCall
@@ -576,6 +579,16 @@ class RunImpl:
                     if isinstance(e, AgentsException):
                         raise e
                     raise UserError(f"Error running tool {func_tool.name}: {e}") from e
+
+                if inspect.isasyncgen(result):
+                    result = await cls._consume_async_generator(
+                        result,
+                        func_tool,
+                        tool_call,
+                        event_queue,
+                    )
+                elif inspect.isgenerator(result):
+                    result = cls._consume_generator(result, func_tool, tool_call, event_queue)
 
                 if config.trace_include_sensitive_data:
                     span_fn.span_data.output = result
@@ -908,6 +921,48 @@ class RunImpl:
 
             if event:
                 queue.put_nowait(event)
+
+    @staticmethod
+    async def _consume_async_generator(
+        gen: AsyncGenerator[Any, None],
+        tool: FunctionTool,
+        tool_call: ResponseFunctionToolCall,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None,
+    ) -> Any:
+        while True:
+            try:
+                value = await gen.__anext__()
+            except StopAsyncIteration as e:
+                return e.value
+            if event_queue is not None:
+                event_queue.put_nowait(
+                    ToolYieldStreamEvent(
+                        tool_name=tool.name,
+                        tool_call_id=tool_call.call_id,
+                        value=value,
+                    )
+                )
+
+    @staticmethod
+    def _consume_generator(
+        gen: Generator[Any, None, Any],
+        tool: FunctionTool,
+        tool_call: ResponseFunctionToolCall,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None,
+    ) -> Any:
+        while True:
+            try:
+                value = next(gen)
+            except StopIteration as e:
+                return e.value
+            if event_queue is not None:
+                event_queue.put_nowait(
+                    ToolYieldStreamEvent(
+                        tool_name=tool.name,
+                        tool_call_id=tool_call.call_id,
+                        value=value,
+                    )
+                )
 
     @classmethod
     async def _check_for_final_output_from_tools(

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -48,7 +48,12 @@ from .models.interface import Model, ModelProvider
 from .models.multi_provider import MultiProvider
 from .result import RunResult, RunResultStreaming
 from .run_context import RunContextWrapper, TContext
-from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent
+from .stream_events import (
+    AgentUpdatedStreamEvent,
+    RawResponsesStreamEvent,
+    StreamEvent,
+    ToolYieldStreamEvent,
+)
 from .tool import Tool
 from .tracing import Span, SpanError, agent_span, get_current_trace, trace
 from .tracing.span_data import AgentSpanData
@@ -866,6 +871,7 @@ class AgentRunner:
             context_wrapper=context_wrapper,
             run_config=run_config,
             tool_use_tracker=tool_use_tracker,
+            event_queue=streamed_result._event_queue,
         )
 
         RunImpl.stream_step_result_to_queue(single_step_result, streamed_result._event_queue)
@@ -933,6 +939,7 @@ class AgentRunner:
             context_wrapper=context_wrapper,
             run_config=run_config,
             tool_use_tracker=tool_use_tracker,
+            event_queue=None,
         )
 
     @classmethod
@@ -950,6 +957,7 @@ class AgentRunner:
         context_wrapper: RunContextWrapper[TContext],
         run_config: RunConfig,
         tool_use_tracker: AgentToolUseTracker,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     ) -> SingleStepResult:
         processed_response = RunImpl.process_model_response(
             agent=agent,
@@ -971,6 +979,7 @@ class AgentRunner:
             hooks=hooks,
             context_wrapper=context_wrapper,
             run_config=run_config,
+            event_queue=event_queue,
         )
 
     @classmethod

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -57,5 +57,26 @@ class AgentUpdatedStreamEvent:
     type: Literal["agent_updated_stream_event"] = "agent_updated_stream_event"
 
 
-StreamEvent: TypeAlias = Union[RawResponsesStreamEvent, RunItemStreamEvent, AgentUpdatedStreamEvent]
+@dataclass
+class ToolYieldStreamEvent:
+    """Event emitted when a tool yields a value."""
+
+    tool_name: str
+    """The name of the tool that yielded."""
+
+    tool_call_id: str
+    """The ID of the tool call."""
+
+    value: Any
+    """The yielded value."""
+
+    type: Literal["tool_yield_stream_event"] = "tool_yield_stream_event"
+
+
+StreamEvent: TypeAlias = Union[
+    RawResponsesStreamEvent,
+    RunItemStreamEvent,
+    AgentUpdatedStreamEvent,
+    ToolYieldStreamEvent,
+]
 """A streaming event from an agent."""


### PR DESCRIPTION
## Summary
- allow tools to yield objects during execution
- stream yielded objects via new `ToolYieldStreamEvent`
- propagate event queues through run implementation
- test yielding objects from tools

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named 'openai.types.responses.response_usage' and others)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_685ea98778c48323860fbc020fa633de

## Summary by Sourcery

Enable tools to yield values during execution and stream them via the new ToolYieldStreamEvent through the runner pipeline

New Features:
- Allow FunctionTools to yield intermediate values as streamed events
- Introduce ToolYieldStreamEvent to represent yielded tool values

Enhancements:
- Propagate event_queue through RunImpl methods to enable streaming
- Add helpers to consume sync and async generator yields from tools

Tests:
- Add test to verify ToolYieldStreamEvent emission for yielded values

Chores:
- Export ToolYieldStreamEvent in the agents public API