### PR TITLE
Add streaming of tool yields during execution

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -54,6 +54,7 @@ from .stream_events import (
     AgentUpdatedStreamEvent,
     RawResponsesStreamEvent,
     RunItemStreamEvent,
+    ToolYieldStreamEvent,
     StreamEvent,
 )
 from .tool import (
@@ -218,6 +219,7 @@ __all__ = [
     "RawResponsesStreamEvent",
     "RunItemStreamEvent",
     "AgentUpdatedStreamEvent",
+    "ToolYieldStreamEvent",
     "StreamEvent",
     "FunctionTool",
     "FunctionToolResult",

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -48,7 +48,12 @@ from .models.interface import Model, ModelProvider
 from .models.multi_provider import MultiProvider
 from .result import RunResult, RunResultStreaming
 from .run_context import RunContextWrapper, TContext
-from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent
+from .stream_events import (
+    AgentUpdatedStreamEvent,
+    RawResponsesStreamEvent,
+    StreamEvent,
+    ToolYieldStreamEvent,
+)
 from .tool import Tool
 from .tracing import Span, SpanError, agent_span, get_current_trace, trace
 from .tracing.span_data import AgentSpanData
@@ -866,6 +871,7 @@ class AgentRunner:
             context_wrapper=context_wrapper,
             run_config=run_config,
             tool_use_tracker=tool_use_tracker,
+            event_queue=streamed_result._event_queue,
         )
 
         RunImpl.stream_step_result_to_queue(single_step_result, streamed_result._event_queue)
@@ -933,6 +939,7 @@ class AgentRunner:
             context_wrapper=context_wrapper,
             run_config=run_config,
             tool_use_tracker=tool_use_tracker,
+            event_queue=None,
         )
 
     @classmethod
@@ -950,6 +957,7 @@ class AgentRunner:
         context_wrapper: RunContextWrapper[TContext],
         run_config: RunConfig,
         tool_use_tracker: AgentToolUseTracker,
+        event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     ) -> SingleStepResult:
         processed_response = RunImpl.process_model_response(
             agent=agent,
@@ -971,6 +979,7 @@ class AgentRunner:
             hooks=hooks,
             context_wrapper=context_wrapper,
             run_config=run_config,
+            event_queue=event_queue,
         )
 
     @classmethod

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -57,5 +57,26 @@ class AgentUpdatedStreamEvent:
     type: Literal["agent_updated_stream_event"] = "agent_updated_stream_event"
 
 
-StreamEvent: TypeAlias = Union[RawResponsesStreamEvent, RunItemStreamEvent, AgentUpdatedStreamEvent]
+@dataclass
+class ToolYieldStreamEvent:
+    """Event emitted when a tool yields a value."""
+
+    tool_name: str
+    """The name of the tool that yielded."""
+
+    tool_call_id: str
+    """The ID of the tool call."""
+
+    value: Any
+    """The yielded value."""
+
+    type: Literal["tool_yield_stream_event"] = "tool_yield_stream_event"
+
+
+StreamEvent: TypeAlias = Union[
+    RawResponsesStreamEvent,
+    RunItemStreamEvent,
+    AgentUpdatedStreamEvent,
+    ToolYieldStreamEvent,
+]
 """A streaming event from an agent."""


### PR DESCRIPTION
## Summary
- stream generator yields from tools in real time
- update ToolYieldStreamEvent handling
- verify yield events arrive before tool output

## Testing
- `ruff format src/agents/_run_impl.py tests/test_agent_runner_streamed.py src/agents/stream_events.py`
- `ruff check src/agents/_run_impl.py tests/test_agent_runner_streamed.py src/agents/stream_events.py`
- `mypy .` *(fails: Cannot find implementation or library stub for module named 'numpy' and others)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_685ea98778c48323860fbc020fa633de

## Summary by Sourcery

Add real-time streaming of tool generator yields by emitting ToolYieldStreamEvent during execution

New Features:
- Emit a new ToolYieldStreamEvent whenever a tool yield occurs

Enhancements:
- Propagate an optional event_queue through the tool execution flow
- Implement _consume_async_generator and _consume_generator to enqueue yielded values

Documentation:
- Document the new ToolYieldStreamEvent and update the StreamEvent union type

Tests:
- Add test to verify yield events are emitted before tool output